### PR TITLE
Don't have packaging.tags.compatible_tags() reuse an iterable (#258)

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -315,7 +315,7 @@ def _py_interpreter_range(py_version):
 def compatible_tags(
     python_version=None,  # type: Optional[PythonVersion]
     interpreter=None,  # type: Optional[str]
-    platforms=None,  # type: Optional[Iterator[str]]
+    platforms=None,  # type: Optional[Iterable[str]]
 ):
     # type: (...) -> Iterator[Tag]
     """
@@ -328,8 +328,7 @@ def compatible_tags(
     """
     if not python_version:
         python_version = sys.version_info[:2]
-    if not platforms:
-        platforms = _platform_tags()
+    platforms = list(platforms or _platform_tags())
     for version in _py_interpreter_range(python_version):
         for platform_ in platforms:
             yield Tag(version, "none", platform_)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -923,12 +923,15 @@ class TestCompatibleTags:
         ]
 
     def test_default_platforms(self, monkeypatch):
-        monkeypatch.setattr(tags, "_platform_tags", lambda: ["plat"])
+        monkeypatch.setattr(tags, "_platform_tags", lambda: iter(["plat", "plat2"]))
         result = list(tags.compatible_tags((3, 1), "cp31"))
         assert result == [
             tags.Tag("py31", "none", "plat"),
+            tags.Tag("py31", "none", "plat2"),
             tags.Tag("py3", "none", "plat"),
+            tags.Tag("py3", "none", "plat2"),
             tags.Tag("py30", "none", "plat"),
+            tags.Tag("py30", "none", "plat2"),
             tags.Tag("cp31", "none", "any"),
             tags.Tag("py31", "none", "any"),
             tags.Tag("py3", "none", "any"),


### PR DESCRIPTION
The code was using an iterable in an inner loop which would lead to iterator exhaustion after the first time round the loop.

Closes #257